### PR TITLE
fix: Rabbitmq Queue's improvements 

### DIFF
--- a/dist/contracts/BrokherContract.d.ts
+++ b/dist/contracts/BrokherContract.d.ts
@@ -1,7 +1,8 @@
-export interface BrokherContract<BrokherConfig, BrokherChannel> {
+export interface BrokherContract<BrokherConfig, BrokherChannel, BrokherOptions> {
     setConnection(config: BrokherConfig): any;
     setChannel(channel: string, options: BrokherChannel): any;
     createChannel(connection: any): any;
     publish(topic: string, content: Object): Promise<Boolean>;
-    subscribe(topicName: string, callback: Function): any;
+    subscribe(topicName: string, callback: Function, options: BrokherOptions): any;
+    setQueue(queue: string): any;
 }

--- a/dist/contracts/RabbitMQ/index.d.ts
+++ b/dist/contracts/RabbitMQ/index.d.ts
@@ -1,20 +1,24 @@
-import { Options } from 'amqplib';
+import { Channel, Options } from 'amqplib';
 import { BrokherContract } from '../BrokherContract';
 interface RabbitMQConfig {
     uri: string;
 }
-export default class RabbitMQ implements BrokherContract<RabbitMQConfig, Options.AssertExchange> {
+export default class RabbitMQ implements BrokherContract<RabbitMQConfig, Options.AssertExchange, Options.AssertQueue> {
     private connectionUrl;
     private exchange;
     private routingKey;
-    setConnection({ uri }: RabbitMQConfig): RabbitMQ;
+    private ch;
+    private conn;
+    private queue;
+    setConnection({ uri, }: RabbitMQConfig): RabbitMQ;
     static init(): RabbitMQ;
     setExchange(exchange: string): RabbitMQ;
+    setQueue(queue: string): RabbitMQ;
     setChannel(channel: string | undefined, options: Options.AssertExchange): RabbitMQ;
-    createChannel(): Promise<import("amqplib").Channel>;
+    createChannel(): Promise<Channel>;
     private createConnection;
     publish(content: Object): Promise<Boolean>;
-    subscribe(listingKey: string, callback: Function): Promise<import("amqplib").Replies.Consume>;
+    subscribe(listingKey: string, callback: Function, options?: Options.AssertQueue): Promise<void>;
     setRoutingKey(key: string): RabbitMQ;
 }
 export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,5 @@
 import { BrokherContract } from './contracts/BrokherContract';
-interface BrokherInterface extends BrokherContract<any, any> {
+interface BrokherInterface extends BrokherContract<any, any, any> {
     init(): BrokherInterface;
 }
 export declare function setup(brokherName: string): Promise<BrokherInterface>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brokher",
-  "version": "0.1.3",
+  "version": "0.1.3-beta",
   "description": "A Wrapper for Message Brokhers",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brokher",
-  "version": "0.1.3-beta",
+  "version": "0.1.3-beta.3",
   "description": "A Wrapper for Message Brokhers",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brokher",
-  "version": "0.1.3-beta.3",
+  "version": "0.1.4",
   "description": "A Wrapper for Message Brokhers",
   "main": "dist/index.js",
   "scripts": {

--- a/src/contracts/BrokherContract.ts
+++ b/src/contracts/BrokherContract.ts
@@ -10,4 +10,5 @@ export interface BrokherContract<BrokherConfig, BrokherChannel, BrokherOptions> 
 
   subscribe(topicName: string, callback: Function, options: BrokherOptions) : any
 
+  setQueue(queue: string) : any
 }

--- a/src/contracts/BrokherContract.ts
+++ b/src/contracts/BrokherContract.ts
@@ -1,4 +1,4 @@
-export interface BrokherContract<BrokherConfig, BrokherChannel> {
+export interface BrokherContract<BrokherConfig, BrokherChannel, BrokherOptions> {
 
   setConnection(config: BrokherConfig) : any
 
@@ -8,6 +8,6 @@ export interface BrokherContract<BrokherConfig, BrokherChannel> {
 
   publish (topic: string, content: Object) : Promise<Boolean>
 
-  subscribe(topicName: string, callback: Function) : any
+  subscribe(topicName: string, callback: Function, options: BrokherOptions) : any
 
 }

--- a/src/contracts/RabbitMQ/index.ts
+++ b/src/contracts/RabbitMQ/index.ts
@@ -102,7 +102,7 @@ export default class RabbitMQ
     callback: Function,
     options: Options.AssertQueue = {
       durable: true,
-      exclusive: true,
+      exclusive: false,
       autoDelete: false,
       messageTtl: 60000,
       deadLetterExchange: 'webhook',
@@ -128,9 +128,15 @@ export default class RabbitMQ
       await ch.consume(
         queue,
         async (message: any) => {
-          const receivedData = JSON.parse(
-            message?.content.toString() as string
-          );
+          let receivedData;
+
+          try {
+            receivedData = JSON.parse(
+              message?.content.toString() as string
+            );
+          } catch {
+            receivedData = message?.content.toString() as string;
+          }
 
           await callback(receivedData);
           this.ch.ack(message);
@@ -140,7 +146,7 @@ export default class RabbitMQ
         }
       );
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { BrokherContract } from './contracts/BrokherContract'
 import { BrokherMapper } from './enums/BrokherMapped'
-interface BrokherInterface extends BrokherContract<any, any> {
+interface BrokherInterface extends BrokherContract<any, any, any> {
   init() : BrokherInterface
 }
 


### PR DESCRIPTION
When subscribe to an queue, costumer can tell to brokher what resources he want's.

And introduce by default manual ack, to garantee not delete when service break's

- And add default options to subscribe
- And now subscriber can name they queue
- Manage better connections, using singleton